### PR TITLE
Update release tooling to only create release tag for multi-module repos

### DIFF
--- a/.changelog/7acbd7a9585346c0bdbf8821390df957.json
+++ b/.changelog/7acbd7a9585346c0bdbf8821390df957.json
@@ -1,0 +1,8 @@
+{
+    "id": "7acbd7a9-5853-46c0-bdbf-8821390df957",
+    "type": "feature",
+    "description": "Update calculate release and tag release to not create release-YYYY-MM-DD releases for single module repositories.",
+    "modules": [
+        "."
+    ]
+}

--- a/cmd/calculaterelease/main.go
+++ b/cmd/calculaterelease/main.go
@@ -62,8 +62,7 @@ func main() {
 	}
 
 	id := release.NextReleaseID(tags)
-
-	manifest, err := release.BuildReleaseManifest(id, modulesForRelease, verbose)
+	manifest, err := release.BuildReleaseManifest(discoverer.Modules(), id, modulesForRelease, verbose)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/moduleversion/README.md
+++ b/cmd/moduleversion/README.md
@@ -1,0 +1,11 @@
+# Description
+
+Utility to get the current version of a Go module. Must be called from within
+the repository the module is defined in. Can also be used to get the projected
+version of an Go module with unreleased changes.
+
+# Usage
+
+```
+moduleversion [-unreleaed] <module relative path>
+```

--- a/cmd/moduleversion/main.go
+++ b/cmd/moduleversion/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	repotools "github.com/awslabs/aws-go-multi-module-repository-tools"
+	"github.com/awslabs/aws-go-multi-module-repository-tools/changelog"
+	"github.com/awslabs/aws-go-multi-module-repository-tools/git"
+	"github.com/awslabs/aws-go-multi-module-repository-tools/gomod"
+	"github.com/awslabs/aws-go-multi-module-repository-tools/release"
+)
+
+var (
+	getUnreleasedVersion bool
+)
+
+func init() {
+	flag.BoolVar(&getUnreleasedVersion, "unreleased", false,
+		"Returns the version the projected version the module will be at after the next release")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s [-unreleased] module\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(flag.CommandLine.Output(), "  module\n\tThe relative path of the module to get the version of.\n")
+		flag.PrintDefaults()
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		flag.Usage()
+		log.Fatalf("no module specified")
+	}
+	moduleToCheck := flag.Args()[0]
+
+	repoRoot, err := repotools.GetRepoRoot()
+	if err != nil {
+		log.Fatalf("failed to get repository root: %v", err)
+	}
+
+	config, err := repotools.LoadConfig(repoRoot)
+	if err != nil {
+		log.Fatalf("failed to load repotools config: %v", err)
+	}
+
+	discoverer := gomod.NewDiscoverer(repoRoot)
+
+	if err := discoverer.Discover(); err != nil {
+		log.Fatalf("failed to discover repository modules: %v", err)
+	}
+
+	tags, err := git.Tags(repoRoot)
+	if err != nil {
+		log.Fatalf("failed to get git tags: %v", err)
+	}
+
+	taggedModules := git.ParseModuleTags(tags)
+
+	annotations, err := changelog.GetAnnotations(repoRoot)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	checkedModules, err := release.Calculate(discoverer, taggedModules, config, annotations)
+	if err != nil {
+		log.Fatalf("failed to check repo modules, %v", err)
+	}
+
+	if getUnreleasedVersion {
+		id := release.NextReleaseID(tags)
+		manifest, err := release.BuildReleaseManifest(discoverer.Modules(), id, checkedModules, false)
+		if err != nil {
+			log.Fatalf("failed to build release manifest, %v", err)
+		}
+
+		if m, ok := manifest.Modules[moduleToCheck]; ok {
+			moduleTag, err := git.ToModuleTag(moduleToCheck, m.To)
+			if err != nil {
+				log.Fatalf("failed to get module %v tag, %v", moduleToCheck, err)
+			}
+			fmt.Println(moduleTag)
+			return
+		}
+	}
+
+	checkedModule, ok := release.FindModuleViaRelativeRepoPath(checkedModules, moduleToCheck)
+	if !ok {
+		log.Fatalf("failed to find version for module, %v", moduleToCheck)
+	}
+
+	moduleVersion := checkedModule.Latest
+	if checkedModule.Latest == "" {
+		moduleVersion = "v0.0.0-00010101000000-000000000000"
+	}
+	fmt.Println(moduleVersion)
+}

--- a/cmd/tagrelease/main.go
+++ b/cmd/tagrelease/main.go
@@ -56,9 +56,11 @@ func main() {
 		}
 	}
 
-	releaseTag := fmt.Sprintf("release-%s", manifest.ID)
-	if err = git.Tag(repoRoot, releaseTag, message, "HEAD"); err != nil {
-		log.Fatalf("failed to create release tag %v: %v", releaseTag, err)
+	if manifest.WithReleaseTag {
+		releaseTag := fmt.Sprintf("release-%s", manifest.ID)
+		if err = git.Tag(repoRoot, releaseTag, message, "HEAD"); err != nil {
+			log.Fatalf("failed to create release tag %v: %v", releaseTag, err)
+		}
 	}
 }
 

--- a/release/calculate.go
+++ b/release/calculate.go
@@ -15,8 +15,10 @@ import (
 
 // ModuleFinder is a type that searches for modules
 type ModuleFinder interface {
+	// Absolute Path of the root directory all modules are nested within.
 	Root() string
 
+	// Returns a tree of the known modules.
 	Modules() *gomod.ModuleTree
 }
 

--- a/release/calculate.go
+++ b/release/calculate.go
@@ -169,12 +169,6 @@ func Calculate(finder ModuleFinder, tags git.ModuleTags, config repotools.Config
 		return nil, err
 	}
 
-	for modulePath := range checkedModules {
-		if checkedModules[modulePath].Changes == 0 || config.Modules[modulePath].NoTag {
-			delete(checkedModules, modulePath)
-		}
-	}
-
 	return checkedModules, nil
 }
 

--- a/release/manifest_schema.json
+++ b/release/manifest_schema.json
@@ -6,6 +6,9 @@
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}(\\.\\d+)?$"
     },
+    "with_release_tag": {
+      "type": "boolean"
+    },
     "modules": {
       "type": "object",
       "patternProperties": {

--- a/release/release.go
+++ b/release/release.go
@@ -240,7 +240,7 @@ func BuildReleaseManifest(moduleTree *gomod.ModuleTree, id string, modules map[s
 		if ok {
 			singleModRepoID = rootChangeModule.To
 		} else {
-			rootRepoModule, ok := findModuleViaRelativeRepoPath(modules, repoModuleList[0].Path())
+			rootRepoModule, ok := FindModuleViaRelativeRepoPath(modules, repoModuleList[0].Path())
 			if !ok {
 				return Manifest{}, fmt.Errorf("root module metadata not found, %v, %v, %v",
 					repoModuleList[0].Path(), modules, rm.Modules)
@@ -257,9 +257,10 @@ func BuildReleaseManifest(moduleTree *gomod.ModuleTree, id string, modules map[s
 	return rm, nil
 }
 
-// Searches through the map of calculated module changes, for a module with the
-// relative repository path specified. If a module is found it will be returned.
-func findModuleViaRelativeRepoPath(modules map[string]*Module, relPath string) (*Module, bool) {
+// FindModuleViaRelativeRepoPath Searches through the map of calculated module
+// changes, for a module with the relative repository path specified. If a
+// module is found it will be returned.
+func FindModuleViaRelativeRepoPath(modules map[string]*Module, relPath string) (*Module, bool) {
 	for _, v := range modules {
 		if v.RelativeRepoPath == relPath {
 			return v, true

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -320,7 +320,7 @@ require (
 				},
 			},
 		},
-		"verbose multi-module": {
+		"multi-module verbose": {
 			ID:      "2021-10-27",
 			Verbose: true,
 			ModuleTree: func() *gomod.ModuleTree {
@@ -376,6 +376,45 @@ require (
 				},
 			},
 		},
+		"multi-module no-change": {
+			ID: "2021-10-27",
+			ModuleTree: func() *gomod.ModuleTree {
+				tree := gomod.NewModuleTree()
+				tree.InsertRel("")
+				tree.InsertRel("config")
+				return tree
+			}(),
+			Modules: map[string]*Module{
+				"github.com/aws/aws-sdk-go-v2": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("go.mod", strings.NewReader(sdkRootGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: ".",
+					Latest:           "v1.0.0",
+				},
+				"github.com/aws/aws-sdk-go-v2/config": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("config/go.mod", strings.NewReader(configGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: "config",
+					Latest:           "v1.0.0",
+				},
+			},
+			ExpectManifest: Manifest{
+				ID:             "2021-10-27",
+				WithReleaseTag: true,
+				Modules:        map[string]ModuleManifest{},
+				Tags:           nil,
+			},
+		},
 		"single-module": {
 			ID: "2021-10-27",
 			ModuleTree: func() *gomod.ModuleTree {
@@ -414,6 +453,33 @@ require (
 				Tags: []string{
 					"v1.2.4",
 				},
+			},
+		},
+		"single-module no-change": {
+			ID: "2021-10-27",
+			ModuleTree: func() *gomod.ModuleTree {
+				tree := gomod.NewModuleTree()
+				tree.InsertRel(".")
+				return tree
+			}(),
+			Modules: map[string]*Module{
+				"github.com/aws/smithy-go": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("go.mod", strings.NewReader(smithyGoRootGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: ".",
+					Latest:           "v1.2.3",
+				},
+			},
+			ExpectManifest: Manifest{
+				ID:             "v1.2.3",
+				WithReleaseTag: false,
+				Modules:        map[string]ModuleManifest{},
+				Tags:           nil,
 			},
 		},
 	}

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -1,10 +1,17 @@
 package release
 
 import (
-	repotools "github.com/awslabs/aws-go-multi-module-repository-tools"
-	"github.com/awslabs/aws-go-multi-module-repository-tools/changelog"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	repotools "github.com/awslabs/aws-go-multi-module-repository-tools"
+	"github.com/awslabs/aws-go-multi-module-repository-tools/changelog"
+	"github.com/awslabs/aws-go-multi-module-repository-tools/gomod"
+	"github.com/google/go-cmp/cmp"
+
+	"golang.org/x/mod/modfile"
 )
 
 type mockFinder struct {
@@ -223,6 +230,203 @@ func TestNextReleaseID(t *testing.T) {
 
 			if gotNext := NextReleaseID(tt.args.tags); gotNext != tt.wantNext {
 				t.Errorf("NextReleaseID() = %v, want %v", gotNext, tt.wantNext)
+			}
+		})
+	}
+}
+
+func TestBuildReleaseManifest(t *testing.T) {
+	const smithyGoRootGoMod = `module github.com/aws/smithy-go
+
+require (
+	github.com/google/go-cmp v0.5.6
+)
+
+go 1.15`
+	const sdkRootGoMod = `module github.com/aws/aws-sdk-go-v2
+
+require (
+	github.com/aws/smithy-go v1.8.1
+	github.com/google/go-cmp v0.5.6
+	github.com/jmespath/go-jmespath v0.4.0
+)
+
+go 1.15`
+	const configGoMod = `module github.com/aws/aws-sdk-go-v2/config
+
+go 1.15
+
+require (
+	github.com/aws/aws-sdk-go-v2 v1.10.0
+	github.com/google/go-cmp v0.5.6
+)`
+	cases := map[string]struct {
+		ModuleTree *gomod.ModuleTree
+		ID         string
+		Modules    map[string]*Module
+		Verbose    bool
+
+		ExpectManifest Manifest
+	}{
+		"multi-module": {
+			ID: "2021-10-27",
+			ModuleTree: func() *gomod.ModuleTree {
+				tree := gomod.NewModuleTree()
+				tree.InsertRel("")
+				tree.InsertRel("config")
+				return tree
+			}(),
+			Modules: map[string]*Module{
+				"github.com/aws/aws-sdk-go-v2": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("go.mod", strings.NewReader(sdkRootGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: ".",
+					Latest:           "v1.0.0",
+				},
+				"github.com/aws/aws-sdk-go-v2/config": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("config/go.mod", strings.NewReader(configGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: "config",
+					Latest:           "v1.0.0",
+					Changes:          SourceChange,
+					FileChanges: []string{
+						"config/foo.go",
+					},
+				},
+			},
+			ExpectManifest: Manifest{
+				ID:             "2021-10-27",
+				WithReleaseTag: true,
+				Modules: map[string]ModuleManifest{
+					"config": {
+						ModulePath: "github.com/aws/aws-sdk-go-v2/config",
+						From:       "v1.0.0",
+						To:         "v1.0.1",
+						Changes:    SourceChange,
+					},
+				},
+				Tags: []string{
+					"config/v1.0.1",
+				},
+			},
+		},
+		"verbose multi-module": {
+			ID:      "2021-10-27",
+			Verbose: true,
+			ModuleTree: func() *gomod.ModuleTree {
+				tree := gomod.NewModuleTree()
+				tree.InsertRel(".")
+				tree.InsertRel("config")
+				return tree
+			}(),
+			Modules: map[string]*Module{
+				"github.com/aws/aws-sdk-go-v2": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("go.mod", strings.NewReader(sdkRootGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: ".",
+					Latest:           "v1.0.0",
+				},
+				"github.com/aws/aws-sdk-go-v2/config": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("config/go.mod", strings.NewReader(configGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: "config",
+					Latest:           "v1.0.0",
+					Changes:          SourceChange,
+					FileChanges: []string{
+						"config/foo.go",
+					},
+				},
+			},
+			ExpectManifest: Manifest{
+				ID:             "2021-10-27",
+				WithReleaseTag: true,
+				Modules: map[string]ModuleManifest{
+					"config": {
+						ModulePath: "github.com/aws/aws-sdk-go-v2/config",
+						From:       "v1.0.0",
+						To:         "v1.0.1",
+						Changes:    SourceChange,
+						FileChanges: []string{
+							"config/foo.go",
+						},
+					},
+				},
+				Tags: []string{
+					"config/v1.0.1",
+				},
+			},
+		},
+		"single-module": {
+			ID: "2021-10-27",
+			ModuleTree: func() *gomod.ModuleTree {
+				tree := gomod.NewModuleTree()
+				tree.InsertRel(".")
+				return tree
+			}(),
+			Modules: map[string]*Module{
+				"github.com/aws/smithy-go": {
+					File: func() *modfile.File {
+						f, err := gomod.ReadModule("go.mod", strings.NewReader(smithyGoRootGoMod), nil, false)
+						if err != nil {
+							panic(fmt.Errorf("expect no error reading module, %v", err).Error())
+						}
+						return f
+					}(),
+					RelativeRepoPath: ".",
+					Latest:           "v1.2.3",
+					Changes:          SourceChange,
+					FileChanges: []string{
+						"config/foo.go",
+					},
+				},
+			},
+			ExpectManifest: Manifest{
+				ID:             "v1.2.4",
+				WithReleaseTag: false,
+				Modules: map[string]ModuleManifest{
+					".": {
+						ModulePath: "github.com/aws/smithy-go",
+						From:       "v1.2.3",
+						To:         "v1.2.4",
+						Changes:    SourceChange,
+					},
+				},
+				Tags: []string{
+					"v1.2.4",
+				},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			manifest, err := BuildReleaseManifest(tt.ModuleTree, tt.ID, tt.Modules, tt.Verbose)
+			if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+
+			if diff := cmp.Diff(tt.ExpectManifest, manifest); diff != "" {
+				t.Errorf("expect manifest match, got\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Updates the release tooling so that calculaterelease and tagrelease only create the release-YYYY-MM-DD tag for multi-module releases. Single module repositories will use the root module's tag for the release manifest ID.

Adds a utility `moduleversion` to return the Go module's current version or when used with `-unreleased` returns the module's projected version on the next release.
