### PR TITLE
Add utility to modify modman.toml dependencies

### DIFF
--- a/cmd/editmoduledependency/README.md
+++ b/cmd/editmoduledependency/README.md
@@ -1,0 +1,21 @@
+# Description
+
+Utility to update a repository's module management (modman.toml) file. Supports
+setting a module and version, or deleting an existing module.
+
+# Usage
+
+Add or update a module dependency. Sets a module version to be used in the
+management file. If the module exists it will be updated. If it does not exist
+it will be added.
+
+```
+editmoduledependency -s github.com/aws/smithy-go -v v1.8.2
+```
+
+Delete a module dependency. Removes a module from the management file, if it
+exists. Exists with non-zero code if module does not exist.
+
+```
+editmoduledependency -d github.com/aws/smithy-go
+```

--- a/cmd/editmoduledependency/main.go
+++ b/cmd/editmoduledependency/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	repotools "github.com/awslabs/aws-go-multi-module-repository-tools"
+)
+
+var (
+	setModule    string
+	deleteModule string
+	version      string
+)
+
+func init() {
+	flag.StringVar(&setModule, "s", "",
+		"Sets the `module` version into the repositories module management file. (Requires version)")
+	flag.StringVar(&deleteModule, "d", "",
+		"Deletes the `module` from the repositories module management file.")
+	flag.StringVar(&version, "v", "", "The `version` of the Go module dependency set. (Only usable with set mode)")
+
+	flag.Usage = func() {
+		baseFilename := filepath.Base(os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "Usages:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Set:\n  %s -s <module> -v <version>\n", baseFilename)
+		fmt.Fprintf(flag.CommandLine.Output(), "Delete:\n  %s -d <module>\n", baseFilename)
+		fmt.Fprintf(flag.CommandLine.Output(), "\nOptions:\n")
+		flag.PrintDefaults()
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	if !((setModule == "" || deleteModule == "") && !(setModule == "" && deleteModule == "")) {
+		flag.Usage()
+		log.Fatalf("Use either set or delete mode")
+	}
+	if setModule != "" && version == "" {
+		flag.Usage()
+		log.Fatalf("Set mode requires both module and version")
+	}
+	if deleteModule != "" && version != "" {
+		flag.Usage()
+		log.Fatalf("Delete mode cannot be use with version")
+	}
+
+	repoRoot, err := repotools.GetRepoRoot()
+	if err != nil {
+		log.Fatalf("Failed to get repository root: %v", err)
+	}
+
+	config, err := repotools.LoadConfig(repoRoot)
+	if err != nil {
+		log.Fatalf("Failed to load repotools config: %v", err)
+	}
+
+	if setModule != "" {
+		config, err = setModuleDependency(config, setModule, version)
+	} else {
+		config, err = deleteModuleDependency(config, deleteModule)
+	}
+	if err != nil {
+		log.Fatalf("Failed to modify module dependency, %v", err)
+	}
+
+	if err = repotools.WriteConfig(repoRoot, config); err != nil {
+		log.Fatalf("Failed to write module management file, %v", err)
+	}
+}
+
+func setModuleDependency(config repotools.Config, module, verison string) (repotools.Config, error) {
+	if v, ok := config.Dependencies[module]; ok {
+		log.Printf("Updating module dependency %v: %v, to %v: %v", module, v, module, version)
+	} else {
+		log.Printf("Adding module dependency %v: %v", module, version)
+	}
+
+	config.Dependencies[module] = version
+
+	return config, nil
+}
+
+func deleteModuleDependency(config repotools.Config, module string) (repotools.Config, error) {
+	if v, ok := config.Dependencies[module]; ok {
+		log.Printf("Deleting module dependency %v: %v", module, v)
+	} else {
+		return repotools.Config{}, fmt.Errorf("module %v is not a dependency", module)
+	}
+
+	delete(config.Dependencies, module)
+
+	return config, nil
+}

--- a/config.go
+++ b/config.go
@@ -1,11 +1,12 @@
 package repotools
 
 import (
-	"github.com/pelletier/go-toml"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pelletier/go-toml"
 )
 
 const toolingConfigFile = "modman.toml"
@@ -29,11 +30,18 @@ type Config struct {
 	Dependencies map[string]string       `toml:"dependencies"`
 }
 
+func newConfig() Config {
+	return Config{
+		Modules:      map[string]ModuleConfig{},
+		Dependencies: map[string]string{},
+	}
+}
+
 // LoadConfig loads the tooling configuration file located in the directory path.
 func LoadConfig(path string) (Config, error) {
 	file, err := os.Open(filepath.Join(path, toolingConfigFile))
 	if err != nil && os.IsNotExist(err) {
-		return Config{}, nil
+		return newConfig(), nil
 	} else if err != nil {
 		return Config{}, err
 	}
@@ -43,12 +51,13 @@ func LoadConfig(path string) (Config, error) {
 }
 
 // ReadConfig reads the tooling configuration from the given reader.
-func ReadConfig(reader io.Reader) (c Config, err error) {
+func ReadConfig(reader io.Reader) (Config, error) {
 	all, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
+	c := newConfig()
 	if err = toml.Unmarshal(all, &c); err != nil {
 		return Config{}, err
 	}
@@ -59,7 +68,7 @@ func ReadConfig(reader io.Reader) (c Config, err error) {
 // WriteConfig writes the tooling configuration to the given path.
 func WriteConfig(path string, config Config) (err error) {
 	var f *os.File
-	f, err = os.OpenFile(filepath.Join(path, toolingConfigFile), os.O_CREATE|os.O_TRUNC, 0644)
+	f, err = os.OpenFile(filepath.Join(path, toolingConfigFile), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a new utility, `editmoduledependency` to the repotools that allows
Adding or updating a module's dependency version, or deleting a module
dependency from the module management file (modman.toml)

Also fixes bug in WriteConfig's write file permissions.
