### PR TITLE
Add support for reading changelog description from file or stdin

### DIFF
--- a/.changelog/45c2a070d9894b628a244c2fc5335970.json
+++ b/.changelog/45c2a070d9894b628a244c2fc5335970.json
@@ -1,0 +1,8 @@
+{
+    "id": "45c2a070-d989-4b62-8a24-4c2fc5335970",
+    "type": "bugfix",
+    "description": "Add support for reading a changelog description from a file or stdin.",
+    "modules": [
+        "."
+    ]
+}


### PR DESCRIPTION
Add support for reading changelog description from file or stdin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
