### PR TITLE
cmd/gomodegen: Add support for other SmithyArtifact plugins

### DIFF
--- a/.changelog/f09d84a765424a25ad80a7610ddcd7d2.json
+++ b/.changelog/f09d84a765424a25ad80a7610ddcd7d2.json
@@ -1,0 +1,8 @@
+{
+    "id": "f09d84a7-6542-4a25-ad80-a7610ddcd7d2",
+    "type": "feature",
+    "description": "cmd/gomodgen: Adds configurable support for additional SmithyArtifact generator plugins in addition to go-codegen.",
+    "modules": [
+        "."
+    ]
+}

--- a/cmd/gomodgen/main.go
+++ b/cmd/gomodgen/main.go
@@ -21,10 +21,13 @@ const manifestFileName = "generated.json"
 
 var config = struct {
 	BuildArtifactPath string
+	PluginDirectory   string
 }{}
 
 func init() {
 	flag.StringVar(&config.BuildArtifactPath, "build", "", "build artifact path")
+	flag.StringVar(&config.PluginDirectory, "plugin-dir", "go-codegen",
+		"path individual module source is nested under build artifact.")
 }
 
 func main() {
@@ -55,17 +58,18 @@ func main() {
 		log.Fatalf("unable to determine repo root module path, %v", err)
 	}
 
-	av := manifest.SmithyArtifactPaths{}
+	av := manifest.NewSmithyArtifactPaths(config.PluginDirectory)
 	if err = filepath.Walk(config.BuildArtifactPath, av.Walk); err != nil {
 		log.Fatalf("failed to walk build artifacts: %v", err)
 	}
 
-	if len(av) == 0 {
+	artifactPaths := av.ArtifactPaths()
+	if len(artifactPaths) == 0 {
 		log.Printf("no build artifacts found: %v", err)
 		return
 	}
 
-	if err := copyBuildArtifacts(av, rootModulePath, repoRoot); err != nil {
+	if err := copyBuildArtifacts(artifactPaths, rootModulePath, repoRoot); err != nil {
 		log.Fatalf("failed to copy build artifacts: %v", err)
 	}
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -71,7 +71,18 @@ func ReadManifest(reader io.Reader) (m Manifest, err error) {
 // SmithyArtifactPaths is a slice of smithy-go build artifacts.
 // See the Walk method which can be used for finding the generated Go
 // source code from the Smithy build plugins projection.
-type SmithyArtifactPaths []string
+type SmithyArtifactPaths struct {
+	pluginDirectory string
+	paths           []string
+}
+
+// NewSmithyArtifactPaths initializes the SmithyArtifactPaths for the plugin
+// directory modules should be generated from.
+func NewSmithyArtifactPaths(pluginDir string) *SmithyArtifactPaths {
+	return &SmithyArtifactPaths{
+		pluginDirectory: pluginDir,
+	}
+}
 
 // Walk is a filepath.WalkFunc compatible method that can be used for finding
 // smithy-go plugin build artifacts.
@@ -84,7 +95,7 @@ func (a *SmithyArtifactPaths) Walk(path string, info os.FileInfo, err error) err
 		return nil
 	}
 
-	pluginOutput := filepath.Join(path, "go-codegen")
+	pluginOutput := filepath.Join(path, a.pluginDirectory)
 	stat, err := os.Stat(pluginOutput)
 	if err != nil {
 		return nil
@@ -94,7 +105,12 @@ func (a *SmithyArtifactPaths) Walk(path string, info os.FileInfo, err error) err
 		return nil
 	}
 
-	*a = append(*a, pluginOutput)
+	a.paths = append(a.paths, pluginOutput)
 
 	return filepath.SkipDir
+}
+
+// WalkedPaths returns a copy of the artifact paths that were found.
+func (a *SmithyArtifactPaths) ArtifactPaths() []string {
+	return append([]string{}, a.paths...)
 }


### PR DESCRIPTION
Adds configurable support for additional SmithyArtifact generator
plugins in addition to `go-codegen`.

```sh
go run gomodgen -build "artifact build root path" -plugin-dir "another plugin name"
```