### PR TITLE
fix: remove remote operations

### DIFF
--- a/cmd/updaterequires/main.go
+++ b/cmd/updaterequires/main.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
+
 	repotools "github.com/awslabs/aws-go-multi-module-repository-tools"
 	"github.com/awslabs/aws-go-multi-module-repository-tools/git"
 	"github.com/awslabs/aws-go-multi-module-repository-tools/gomod"
 	"github.com/awslabs/aws-go-multi-module-repository-tools/release"
-	"io/ioutil"
-	"log"
 )
 
 var config = struct {
@@ -83,13 +84,9 @@ func getDependencies(path string) (map[string]string, error) {
 }
 
 func getRepoTags(path string) (git.ModuleTags, error) {
-	if err := git.Fetch(path); err != nil {
-		return nil, err
-	}
-
 	tags, err := git.Tags(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("tags: %v", err)
 	}
 
 	return git.ParseModuleTags(tags), nil


### PR DESCRIPTION
Removes the `fetch` operation performed by `updaterequires`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
