### PR TITLE
Don't retun err if go.mod exists

### DIFF
--- a/cmd/gomodgen/main.go
+++ b/cmd/gomodgen/main.go
@@ -229,7 +229,7 @@ func copyArtifact(sourcePath, targetPath string) (err error) {
 	}
 	defer sourceFile.Close()
 
-	targetFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	targetFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We made a change on aws/smithy-go#558 that changes the default for a Go project to generate a `go.mod` file by default. This broke the existing workflow on aws/aws-sdk-go-v2 since `generate` now fails with

```
+ go run github.com/awslabs/aws-go-multi-module-repository-tools/cmd/gomodgen@latest -build /Volumes/workplace/go-sdk/aws-sdk-go-v2/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen
2024/12/18 15:01:52 failed to copy build artifacts: failed to copy build artifact to target: open /Volumes/workplace/go-sdk/aws-sdk-go-v2/internal/protocoltest/ec2query/go.mod: file exists
```

This changes the line where we open the file to overwrite any existing content.

## Testing
### Setup
I created a fork of the repo since I wasn't able to get it to run locally. I then modified the [copy codegen script](https://github.com/aws/aws-sdk-go-v2/blob/37d3ebb5e69f47b06d75e230a4e520562780170c/codegen/copy_go_codegen.sh#L11) to have the following

```
#!/usr/bin/env bash

set -xe

SDK_ROOT=$1
CODEGEN_ROOT=$2

REPOTOOLS_VERSION="fix-overwrite-existing-gomodo"

cd "$1"
go run github.com/Madrigal/aws-go-multi-module-repository-tools/cmd/gomodgen@${REPOTOOLS_VERSION} -build "$CODEGEN_ROOT"

```

And ran `make`. Ensure clients get generated and tests pass successfully, with no meaningful diff.

The main thing to consider is that all files now have this diff

```
diff --git a/service/amplify/generated.json b/service/amplify/generated.json
index cc33468608..ab676f0a0d 100644
--- a/service/amplify/generated.json
+++ b/service/amplify/generated.json
@@ -52,6 +52,7 @@
         "endpoints_config_test.go",
         "endpoints_test.go",
         "generated.json",
+        "go.mod",
         "internal/endpoints/endpoints.go",
         "internal/endpoints/endpoints_test.go",
         "options.go",
@@ -63,7 +64,7 @@
         "types/types.go",
         "validators.go"
     ],
-    "go": "1.15",
+    "go": "1.21",
     "module": "github.com/aws/aws-sdk-go-v2/service/amplify",
     "unstable": false
 }
```

Which I suspect should be fine since I think these files are just informative, but someone correct me if I'm wrong

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
