### PR TITLE
don't create changelogs for no_tag modules

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: [1.17]
+        go-version: [1.24]
     steps:
     - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Install golint
-      if: ${{ matrix.go-version == '1.17' }}
+      if: ${{ matrix.go-version == '1.24' }}
       run: go install golang.org/x/lint/golint@latest
 
     - name: Unit Test

--- a/cmd/annotatestablegen/main.go
+++ b/cmd/annotatestablegen/main.go
@@ -45,6 +45,11 @@ func main() {
 
 	moduleTags := git.ParseModuleTags(tags)
 
+	cfg, err := repotools.LoadConfig(repoRoot)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
 	discoverer := gomod.NewDiscoverer(repoRoot)
 
 	if err := discoverer.Discover(); err != nil {
@@ -62,6 +67,10 @@ func main() {
 		module := it.Next()
 		if module == nil {
 			break
+		}
+
+		if mcfg, ok := cfg.Modules[module.Path()]; ok && mcfg.NoTag {
+			continue
 		}
 
 		fullPath := module.AbsPath()

--- a/cmd/changelog/create.go
+++ b/cmd/changelog/create.go
@@ -211,7 +211,7 @@ func interactiveEdit(annotation *changelog.Annotation, modules *gomod.ModuleTree
 			sb.WriteString(issue)
 			sb.WriteRune('\n')
 		}
-		return fmt.Errorf(sb.String())
+		return fmt.Errorf("%s", sb.String())
 	}
 
 	// Ensure this didn't get swapped / changed

--- a/cmd/generatechangelog/summary_test.go
+++ b/cmd/generatechangelog/summary_test.go
@@ -83,7 +83,7 @@ func Test_executeModuleTemplate(t *testing.T) {
 			}
 			gotWr := wr.String()
 			if diff := cmp.Diff(tt.wantWr, gotWr); len(diff) > 0 {
-				t.Errorf(diff)
+				t.Errorf("%s", diff)
 			}
 		})
 	}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -146,6 +146,6 @@ func TestModuleTags_Add(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, moduleTags); len(diff) > 0 {
-		t.Errorf(diff)
+		t.Errorf("%s", diff)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/aws-go-multi-module-repository-tools
 
-go 1.17
+go 1.24
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
annotatestablegen is the tool that goes and creates the "new module" changelog for anything that has yet to be tagged. obviously if something was configured for no_tag it should not do that.

I tested this over in the SDK by compiling the annotatestablegen command and temporarily patching the makefile to run that version instead of pulling latest from github.